### PR TITLE
[5.5] Add a new line after the @json blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
@@ -18,6 +18,6 @@ trait CompilesJson
 
         $depth = $parts[2] ?? 512;
 
-        return "<?php echo json_encode($parts[0], $options, $depth) ?>";
+        return "<?php echo json_encode($parts[0], $options, $depth) . PHP_EOL ?>";
     }
 }


### PR DESCRIPTION
This pull request adds a new line after the JSON encoding of the `@json` blade directive.

We've experienced a bug when using the `@json` blade directive in the following scenario:

```js
<script>
  var foo = @json($foo)
  var bar = 2
</script>
```

The above output will return something like this:

```js
<script>
  var foo = {"id": 1}    var bar = 2
</script>
```

Obviously, we get a syntax error with that output. Adding a new line at the end of `@json` fixes this problem and will return the following output:

```js
<script>
  var foo = {"id": 1}    
  var bar = 2
</script>
```
